### PR TITLE
Fix 'reliable search term' for double-dash paths

### DIFF
--- a/src/main/scala/ophan/google/index/checker/model/ContentSummary.scala
+++ b/src/main/scala/ophan/google/index/checker/model/ContentSummary.scala
@@ -21,9 +21,16 @@ case class ContentSummary(
    * reliably should get this content as one of the top hits. The headline of
    * the article would be one candidate for the value, but the headlines can
    * contain characters that are difficult to escape, eg quotes & double-quotes.
-   * The path of the webUrl is fairly reliable, so far as I can see.
+   *
+   * We previously used the quoted path of the webUrl, but that failed
+   * to find results when the path contained double-dashes (eg "england--bond") like
+   * https://www.theguardian.com/business/live/2022/oct/11/bank-of-england--bond-markets-gilts-uk-unemployment-ifs-spending-cuts-imf-outlook-business-live
+   *
+   * Google themselves recommend simply using the full url: "For a missing page:
+   * Search Google for the full URL of your page." - https://support.google.com/webmasters/answer/7474347?hl=en
+   *
    */
-  val reliableSearchTerm: String = s""""${webUrl.getPath}""""
+  val reliableSearchTerm: String = webUrl.toString
 
   val googleSearchUiUrl: URI = URI.create(s"https://www.google.com/search?q=${URLEncoder.encode(reliableSearchTerm, UTF_8)}")
 


### PR DESCRIPTION
We previously used the quoted path of the webUrl, but that failed to find results when the path contained double-dashes (eg `england--bond`) like https://www.theguardian.com/business/live/2022/oct/11/bank-of-england--bond-markets-gilts-uk-unemployment-ifs-spending-cuts-imf-outlook-business-live

This led to us occasionally incorrectly recording content as missing from Google when in fact it was not!

Google themselves [recommend](https://support.google.com/webmasters/answer/7474347?hl=en) simply using the full url: _"For a missing page: Search Google for the full URL of your page."_

Note that https://github.com/guardian/ophan/pull/4969 is the corresponding change in the main Ophan codebase.

#### Before - searching using double-quoted path
https://www.google.com/search?q=%22business%2Flive%2F2022%2Foct%2F11%2Fbank-of-england--bond-markets-gilts-uk-unemployment-ifs-spending-cuts-imf-outlook-business-live%22
![image](https://user-images.githubusercontent.com/52038/195127343-a592cdc7-5bf8-4efd-a314-df4cd77fc35e.png)

#### After - searching using full url (unquoted)
https://www.google.com/search?q=https%3A%2F%2Fwww.theguardian.com%2Fbusiness%2Flive%2F2022%2Foct%2F11%2Fbank-of-england--bond-markets-gilts-uk-unemployment-ifs-spending-cuts-imf-outlook-business-live
![image](https://user-images.githubusercontent.com/52038/195127515-0345bfa8-6824-4f54-a3f5-f32859b228a4.png)


