### PR TITLE
Specify Java 11 In Scalac Options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ scalaVersion := "3.2.1"
 
 scalacOptions ++= Seq(
   "-deprecation",
-  "-encoding", "UTF-8"
+  "-encoding", "UTF-8",
+  "-release:11"
 )
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
## What does this change?

Specifies a Java version to build against. Build tools like `sbt` and those used by IDE tools like Metals can use this to prevent you from using Java APIs that aren't available in the specified Java version. If you are developing using Java 17 but specify 11, you will only be able to use APIs available in 11.

### Demo Video

https://user-images.githubusercontent.com/53781962/204552912-759a49fc-168f-4b56-9a2e-fae7e7b5dfeb.mov
