### PR TITLE
Deprecate Custom Search Site Restricted JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
 # Ophan Google Search Index Checker
 
 _Checking if Guardian content appears in Google search_
- 
+
 Guardian staff: For more background on this issue, see this Guardian-scoped [document](https://docs.google.com/document/d/1lWOM-6mkGaPsI0YpF2HjrkI--6X1AlinaeIOhfmCy4I/edit?hl=en-GB&forcehl=1).
 
 ## Steps performed by the checker
 
-1. Hits the Guardian's Content API (CAPI) for stories published in the last few hours. 
-2. Hits [Google Custom Search Site Restricted JSON API](https://developers.google.com/custom-search/v1/site_restricted_api)
+1. Hits the Guardian's Content API (CAPI) for stories published in the last few hours.
+2. Hits [Discovery Engine API (service is named Google Vertex Agent Builder)](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest)
    to check if our stories are available in Google search.
-   [API Consumption](https://console.cloud.google.com/apis/api/customsearch.googleapis.com/metrics?project=ophan-reborn-2017) &
+   [API Consumption](https://console.cloud.google.com/gen-app-builder/monitoring?inv=1&invt=AbigZA&project=ophan-reborn-2017) &
    [Cost 💰💰💰](https://console.cloud.google.com/apis/api/customsearch.googleapis.com/cost?project=ophan-reborn-2017)
    for this can be monitored in the Google Cloud console.
 3. Stores whether each article is available (or not) in an AWS DynamoDb table.
+
+## Vertex Agent Builder
+
+When setting up search functionality in the GCP Agent Builder, we need to create both an app and a dataStore in the Agent Builder for each website we want to search (in this case theguardian.com, while our [separate indexing system](https://github.com/guardian/google-search-indexing-observatory/tree/main) handles BBC, DailyMail, and NYT).
+While GCP's interface suggests this process creates a new search engine with its own database, this isn't actually what happens. Instead, it creates a filtered view of Google Search results, limited to the specific website URL we specify.
+_Note:_ Even though our code doesn't directly reference the App ID, you must still create both the app and the dataStore for each website - creating just the dataStore isn't sufficient and leads to API errors.
 
 ## Running the Checker locally
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.5.3",
   "com.lihaoyi" %% "upickle" % "3.2.0",
   "com.madgag" %% "scala-collection-plus" % "0.11",
-  "com.google.http-client" % "google-http-client-gson" % "1.44.1",
   "org.scanamo" %% "scanamo" % "1.0.0",
   ("com.gu" %% "content-api-client-default" % "25.0.0").cross(CrossVersion.for3Use2_13),
   "org.scalatest" %% "scalatest" % "3.2.18" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ libraryDependencies ++= Seq(
 
   "com.madgag" %% "scala-collection-plus" % "0.11",
   "com.google.http-client" % "google-http-client-gson" % "1.43.3",
-  "com.google.apis" % "google-api-services-customsearch" % "v1-rev20230319-2.0.0",
   "org.scanamo" %% "scanamo" % "1.0.0-M26",
   ("com.gu" %% "content-api-client-default" % "19.3.1").cross(CrossVersion.for3Use2_13),
   "org.scalatest" %% "scalatest" % "3.2.16" % Test

--- a/src/main/scala/ophan/google/index/checker/GoogleSearchService.scala
+++ b/src/main/scala/ophan/google/index/checker/GoogleSearchService.scala
@@ -1,56 +1,80 @@
 package ophan.google.index.checker
 
-import com.google.api.client.http.HttpRequest
-import com.google.api.client.http.javanet.NetHttpTransport
-import com.google.api.client.json.gson.GsonFactory
-import com.google.api.services.customsearch.v1.CustomSearchAPI
-import com.google.api.services.customsearch.v1.model.{Result, Search}
 import ophan.google.index.checker.GoogleSearchService.resultMatches
-import ophan.google.index.checker.model.{CheckReport, ContentSummary}
+import upickle.default.*
 
 import java.net.URI
+import java.net.http.{HttpClient, HttpRequest}
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future, blocking}
-import scala.jdk.CollectionConverters._
 import scala.util.Try
+import ophan.google.index.checker.model.{CheckReport, ContentSummary}
+
+case class DerivedStructData(link: String)
+
+object DerivedStructData {
+  implicit val rw: ReadWriter[DerivedStructData] = macroRW
+}
+
+case class Document(derivedStructData: DerivedStructData)
+
+object Document {
+  implicit val rw: ReadWriter[Document] = macroRW
+}
+
+case class SearchResult(document: Document)
+
+object SearchResult {
+  implicit val rw: ReadWriter[SearchResult] = macroRW
+}
+
+case class SearchResponse(results: List[SearchResult])
+
+object SearchResponse {
+  implicit val rw: ReadWriter[SearchResponse] = macroRW
+}
 
 class GoogleSearchService(
-  apiKey: String
-)(implicit
-  ec: ExecutionContext
-) {
-  val search =
-    new CustomSearchAPI.Builder(
-      new NetHttpTransport,
-      new GsonFactory,
-      (request: HttpRequest) => {
-        request.getHeaders.setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36")
+                           projectId: String,
+                           location: String,
+                           dataStoreId: String,
+                           apiKey: String
+                         )(implicit ec: ExecutionContext) {
 
-      }
-    ).setApplicationName("search-index-checker").build()
+  private val baseUrl = s"https://discoveryengine.googleapis.com/v1/projects/$projectId/locations/$location/dataStores/$dataStoreId/servingConfigs/default_config:searchLite"
 
-  def contentAvailabilityInGoogleIndex(content: ContentSummary): Future[CheckReport] = Future { blocking {
-      val listRequest = search.cse.siterestrict.list()
-        .setKey(apiKey)
-        .setCx("415ef252844d240a7") // see https://programmablesearchengine.google.com/controlpanel/all
-        .setQ(content.reliableSearchTerm)
-      CheckReport(Instant.now, accessGoogleIndex = Try(listRequest.execute()).map { googleSearchResponse =>
-        findContentMatchInGoogleSearchResponse(googleSearchResponse, content.webUrl).isDefined
+  private val httpClient = HttpClient.newHttpClient()
+
+  def contentAvailabilityInGoogleIndex(content: ContentSummary): Future[CheckReport] = Future {
+    blocking {
+      val requestBody = ujson.Obj(
+        "query" -> content.reliableSearchTerm,
+        "pageSize" -> 10
+      )
+
+      val request = HttpRequest.newBuilder()
+        .uri(URI.create(s"$baseUrl?key=$apiKey"))
+        .header("Content-Type", "application/json")
+        .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+        .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
+        .build()
+
+      CheckReport(Instant.now, accessGoogleIndex = Try {
+        val response = httpClient.send(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+
+        val searchResponse = read[SearchResponse](response.body())
+
+        searchResponse.results.exists { result =>
+          resultMatches(content.webUrl, result)
+        }
       })
     }
   }
-
-  def findContentMatchInGoogleSearchResponse(googleSearchResponse: Search, webUrl: URI): Option[com.google.api.services.customsearch.v1.model.Result] = {
-    Option(googleSearchResponse.getItems).flatMap { items =>
-      items.asScala.toSeq.find { result => resultMatches(webUrl, result) }
-    }
-  }
-
 }
 
 object GoogleSearchService {
-  def resultMatches(webUrl: URI, result: Result): Boolean = Option(result.getLink).exists { link =>
-    val resultUri = URI.create(link)
+  def resultMatches(webUrl: URI, result: SearchResult): Boolean = {
+    val resultUri = URI.create(result.document.derivedStructData.link)
     resultUri.getHost == webUrl.getHost && resultUri.getPath == webUrl.getPath
   }
 }

--- a/src/main/scala/ophan/google/index/checker/GoogleSearchService.scala
+++ b/src/main/scala/ophan/google/index/checker/GoogleSearchService.scala
@@ -60,7 +60,6 @@ class GoogleSearchService(
           .build()
 
         val response = httpClient.send(request, java.net.http.HttpResponse.BodyHandlers.ofString())
-        print(response.body())
 
         val searchResponse = read[SearchResponse](response.body())
         searchResponse.results.exists { result =>
@@ -72,6 +71,7 @@ class GoogleSearchService(
         val initialResult = performSearch(content.reliableSearchTerm)
 
         if (!initialResult) {
+          println(s"executing fallback for ${content.id}")
           performSearch(content.webTitle)
         } else {
           initialResult

--- a/src/main/scala/ophan/google/index/checker/GoogleSearchService.scala
+++ b/src/main/scala/ophan/google/index/checker/GoogleSearchService.scala
@@ -55,7 +55,7 @@ class GoogleSearchService(
       val request = HttpRequest.newBuilder()
         .uri(URI.create(s"$baseUrl?key=$apiKey"))
         .header("Content-Type", "application/json")
-        .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+        .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36")
         .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
         .build()
 

--- a/src/main/scala/ophan/google/index/checker/GoogleSearchService.scala
+++ b/src/main/scala/ophan/google/index/checker/GoogleSearchService.scala
@@ -56,7 +56,6 @@ class GoogleSearchService(
         val request = HttpRequest.newBuilder()
           .uri(URI.create(s"$baseUrl?key=$apiKey"))
           .header("Content-Type", "application/json")
-          .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36")
           .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
           .build()
 

--- a/src/main/scala/ophan/google/index/checker/Lambda.scala
+++ b/src/main/scala/ophan/google/index/checker/Lambda.scala
@@ -22,12 +22,11 @@ object Lambda extends Logging {
   }
 
   val googleSearchService: GoogleSearchService = {
-    val apiKey = fetchKeyFromParameterStore("Google/CustomSearch/ApiKeyNotEncrypted")
-    new GoogleSearchService(apiKey)
+    val apiKey = fetchKeyFromParameterStore("Google/VertexAISearch/ApiKeyNotEncrypted")
+    new GoogleSearchService("ophan-reborn-2017", "global", "ophan-guardian-indexing_1731498624283", apiKey)
   }
 
   val dataStore = new DataStore()
-
 
   // content that we have no 'found' record for - AND have not checked too often/recently
   def contentThatNeedsCheckingNowGiven(

--- a/src/main/scala/ophan/google/index/checker/model/ContentSummary.scala
+++ b/src/main/scala/ophan/google/index/checker/model/ContentSummary.scala
@@ -14,7 +14,8 @@ import scala.math.Ordering.Implicits._
 case class ContentSummary(
   id: String,
   firstPublished: Instant,
-  webUrl: URI
+  webUrl: URI,
+  webTitle: String
 ) {
   /**
    * This string should be something that, when you type it into Google, you
@@ -55,6 +56,6 @@ object ContentSummary {
   def from(content: Content): Option[ContentSummary] = for {
     fields <- content.fields
     firstPublished <- fields.firstPublicationDate
-  } yield ContentSummary(content.id, Instant.ofEpochMilli(firstPublished.dateTime), URI.create(content.webUrl))
+  } yield ContentSummary(content.id, Instant.ofEpochMilli(firstPublished.dateTime), URI.create(content.webUrl), content.webTitle)
 
 }

--- a/src/test/scala/ophan/google/index/checker/GoogleSearchServiceTest.scala
+++ b/src/test/scala/ophan/google/index/checker/GoogleSearchServiceTest.scala
@@ -1,6 +1,5 @@
 package ophan.google.index.checker
 
-import com.google.api.services.customsearch.v1.model.Result
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -12,9 +11,14 @@ class GoogleSearchServiceTest extends AnyFlatSpec with Matchers {
       "https://www.theguardian.com/food/2022/sep/15/korean-hotdogs-k-dogs-sausage-cheese-fast-food?utm_term=Autofeed&CMP=twt_gu&utm_medium&utm_source=Twitter"
 
     val canonicalPageUrl = URI.create("https://www.theguardian.com/food/2022/sep/15/korean-hotdogs-k-dogs-sausage-cheese-fast-food")
-    GoogleSearchService.resultMatches(canonicalPageUrl, resultWithLink(googleResultLink)) shouldBe true
+
+    GoogleSearchService.resultMatches(
+      canonicalPageUrl,
+      SearchResult(
+        Document(
+          DerivedStructData(googleResultLink)
+        )
+      )
+    ) shouldBe true
   }
-
-
-  private def resultWithLink(googleResultLink: String) = new Result().setLink(googleResultLink)
 }

--- a/src/test/scala/ophan/google/index/checker/GoogleSearchServiceTest.scala
+++ b/src/test/scala/ophan/google/index/checker/GoogleSearchServiceTest.scala
@@ -2,12 +2,13 @@ package ophan.google.index.checker
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import upickle.default._
 
 import java.net.URI
 
 class GoogleSearchServiceTest extends AnyFlatSpec with Matchers {
   it should "cope when the google result has tonnes of extra url params" in {
-    val googleResultLink = // Actually seen in Google Search UI and Custom Search API results
+    val googleResultLink =
       "https://www.theguardian.com/food/2022/sep/15/korean-hotdogs-k-dogs-sausage-cheese-fast-food?utm_term=Autofeed&CMP=twt_gu&utm_medium&utm_source=Twitter"
 
     val canonicalPageUrl = URI.create("https://www.theguardian.com/food/2022/sep/15/korean-hotdogs-k-dogs-sausage-cheese-fast-food")
@@ -20,5 +21,40 @@ class GoogleSearchServiceTest extends AnyFlatSpec with Matchers {
         )
       )
     ) shouldBe true
+  }
+
+  it should "handle empty search results" in {
+    val emptyResponse = """{"attributionToken": "token", "summary": {}}"""
+    val searchResponse = read[SearchResponse](emptyResponse)
+    searchResponse.results shouldBe empty
+  }
+
+  it should "not match different paths" in {
+    val url1 = URI.create("https://www.theguardian.com/path1")
+    val url2 = URI.create("https://www.theguardian.com/path2")
+
+    GoogleSearchService.resultMatches(
+      url1,
+      SearchResult(Document(DerivedStructData(url2.toString)))
+    ) shouldBe false
+  }
+
+  it should "parse a search response with results" in {
+    val response = """
+      {
+        "results": [
+          {
+            "document": {
+              "derivedStructData": {
+                "link": "https://www.theguardian.com/article1"
+              }
+            }
+          }
+        ]
+      }
+    """
+    val searchResponse = read[SearchResponse](response)
+    searchResponse.results should have length 1
+    searchResponse.results.head.document.derivedStructData.link shouldBe "https://www.theguardian.com/article1"
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

See issue for context: https://github.com/guardian/ophan/issues/5715

I chose to use the REST API over the Java client library for these reasons:

- The client library not compatible with API keys, only with Oauth 2.0 flow. This means a bit more work setting up service accounts and granting the right permissions to the right services.
- Given the lack of documentation, navigating the client library is time consuming and I think the trade off we get for the strong typing to just make one API call isn't worth it.

Rest docs: https://cloud.google.com/generative-ai-app-builder/docs/reference/rest

Sibling PR in other indexing repo [here](https://github.com/guardian/google-search-indexing-observatory/pull/60).

## Important

During testing, I discovered that approximately 15% of articles available in the old API and Google Search Results cannot be found in the new API. We'll monitor API request volume after this is deployed to track how frequently this occurs.

We intend to contact GCP support about these discrepancies between the old and new APIs, we have a limited relationship with them and it may take a while according to Mike Taylor. We've implemented a fallback solution: when the initial search fails, perform a second search using the article's webTitle instead of the CAPI ID suffix. This alternative method has successfully retrieved the missing articles. See images below.

**Example of article not found in new API:**

https://www.theguardian.com/australia-news/2024/nov/21/afternoon-update-thursday-ntwnfb

1. Article is correctly found (the top one) in Google search results when searching via CAPI ID suffix. This is the same behaviour as the old API:

<img width="1710" alt="Screenshot 2024-11-21 at 11 49 51" src="https://github.com/user-attachments/assets/b730c91f-1711-4811-bb70-e755d95639e3">

2. Article is not found in new API with CAPI id suffix:

<img width="1712" alt="Screenshot 2024-11-21 at 11 49 57" src="https://github.com/user-attachments/assets/ef389f4f-9f6a-46fd-abf8-95189836a092">

3. Article is found in new API using the `webTitle`:

<img width="1718" alt="Screenshot 2024-11-21 at 11 50 25" src="https://github.com/user-attachments/assets/d43aefa7-01a8-463b-a665-e489af8d6540">


## How can we measure success?

Nothing changes.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
