### PR TITLE
Bump netty and jackson deps to solve vulns

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ description:= "Checking whether Guardian content is available in google search"
 version := "1.0"
 
 scalaVersion := "3.3.3"
-val jacksonVersion = "2.18.6"
-val nettyVersion = "4.1.133.Final"
+val jacksonVersion = "2.18.9"
+val nettyVersion = "4.2.16.Final"
 
 scalacOptions ++= Seq(
   "-deprecation",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bump netty and jackson deps to solve vulns.

`jackson-databind` has newer versions, but `jackson-annotations` doesn't, so I'm using the most up-to-date version that's secure and supported by all jackson dependencies.

## How has this change been tested?

I've successfully run the app locally.

Run `sbt run` to do the same.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216600755968668