### PR TITLE
Bump httpcore5 to fix high-severity CVE

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,9 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %% "upickle" % "3.2.0",
   "com.madgag" %% "scala-collection-plus" % "0.11",
   "org.apache.thrift" % "libthrift" % "0.23.0",
+  // Force patched httpcore5 versions: CVE-2026-54399, CVE-2026-54428
+  "org.apache.httpcomponents.core5" % "httpcore5" % "5.4.3",
+  "org.apache.httpcomponents.core5" % "httpcore5-h2" % "5.4.3",
   "org.scanamo" %% "scanamo" % "4.0.0",
   ("com.gu" %% "content-api-client-default" % "40.0.0").cross(CrossVersion.for3Use2_13),
   "org.scalatest" %% "scalatest" % "3.2.18" % Test


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Explicitly declare httpcore5 & httpcore5-h2 (5.3.7)
Addresses 
- https://github.com/guardian/ophan-google-search-index-checker/security/dependabot/139
- https://github.com/guardian/ophan-google-search-index-checker/security/dependabot/140